### PR TITLE
Fix the hostname for the SPAR Soap service

### DIFF
--- a/src/main/java/se/statenspersonadressregister/referensimplementation/installningar/PersonsokInstallningar.java
+++ b/src/main/java/se/statenspersonadressregister/referensimplementation/installningar/PersonsokInstallningar.java
@@ -14,7 +14,7 @@ import static java.util.Arrays.asList;
 public class PersonsokInstallningar {
     private static final Logger log = LoggerFactory.getLogger(PersonsokInstallningar.class);
 
-    private String url = "https://kt-ext-ws.statenspersonadressregister.se/2021.1/";
+    private String url = "https://test-personsok.statenspersonadressregister.se/2021.1/";
 
     // Information om organisationscertifikatet
     private String certifikatSokvag = getClass().getResource("/Kommun_A.p12").getFile();

--- a/src/test/java/se/statenspersonadressregister/referensimplementation/PersonsokExempelTest.java
+++ b/src/test/java/se/statenspersonadressregister/referensimplementation/PersonsokExempelTest.java
@@ -20,7 +20,7 @@ class PersonsokExempelTest {
     static void setup() throws Exception {
         personsokExempel = new PersonsokExempel();
         personsokKlient = personsokExempel.createClient(
-                "https://kt-ext-ws.statenspersonadressregister.se/2021.1/",
+                "https://test-personsok.statenspersonadressregister.se/2021.1/",
                 personsokExempel.createOrganisationscertifikatInformation());
     }
 


### PR DESCRIPTION
The current hostname kt-ext-ws.statenspersonadressregister.se used in this reference implementation fails with a connection error. It should probably be test-personsok.statenspersonadressregister.se instead as this works fine.